### PR TITLE
feat: add Makefile build orchestration and update CI workflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+BreakBeforeBraces: Allman
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+SortIncludes: false
+PointerAlignment: Left

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,55 +7,63 @@ on:
     branches: [ main, master ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+
+      - name: Check changed files formatting
+        run: |
+          git clang-format --diff HEAD~1 > format.patch
+          if [ -s format.patch ]; then
+            echo "Formatting violations found:"
+            cat format.patch
+            exit 1
+          fi
+          echo "Code is properly formatted."
+
   build:
+    needs: lint
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    # --------------------------------
-    # Install system dependencies
-    # --------------------------------
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libcurl4-openssl-dev
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
 
-    - name: Set up CMake
-      uses: lukka/get-cmake@latest
+      - name: Set up CMake
+        uses: lukka/get-cmake@latest
 
-    # --------------------------------
-    # Configure Debug (viewer disabled)
-    # --------------------------------
-    - name: Configure (Debug)
-      run: |
-        cmake -S . -B build-debug -DCMAKE_BUILD_TYPE=Debug -DBUILD_VIEWER=OFF
+      - name: Build
+        run: make -j
 
-    # --------------------------------
-    # Build core + CLI only
-    # --------------------------------
-    - name: Build (Debug)
-      run: |
-        cmake --build build-debug --target orbit_core orbit-sim --parallel
+      - name: Verify CLI
+        run: ./build/bin/orbit-sim --help
 
-    # --------------------------------
-    # Smoke test
-    # --------------------------------
-    - name: Run basic simulation
-      run: |
-        ./build-debug/bin/orbit-sim --help
+  test:
+    needs: lint
+    runs-on: ubuntu-latest
 
-    # --------------------------------
-    # Configure Release
-    # --------------------------------
-    - name: Configure (Release)
-      run: |
-        cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release -DBUILD_VIEWER=OFF
+    steps:
+      - uses: actions/checkout@v4
 
-    # --------------------------------
-    # Build Release
-    # --------------------------------
-    - name: Build (Release)
-      run: |
-        cmake --build build-release --target orbit_core orbit-sim --parallel
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+
+      - name: Set up CMake
+        uses: lukka/get-cmake@latest
+
+      - name: Build
+        run: make -j
+
+      - name: Validate system file
+        run: make validate
+
+      - name: Run test simulation
+        run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,12 @@ jobs:
       - name: Check changed files formatting
         run: |
           git fetch origin main
-          git clang-format-21 origin/main > format.patch
-          if [ -s format.patch ]; then
-            echo "Formatting violations found:"
-            cat format.patch
-            exit 1
+          CHANGED_FILES=$(git diff --name-only origin/main | grep -E '\.(cpp|h)$' | grep -v '^external/' | grep -v '/build/')
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No C++ files changed."
+            exit 0
           fi
-          echo "Code is properly formatted."
+          echo "$CHANGED_FILES" | xargs clang-format-21 --dry-run --Werror
 
   build:
     needs: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,11 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
 
-      - name: Set up CMake
-        uses: lukka/get-cmake@latest
+      - name: Configure CMake
+        run: cmake -S . -B build -DBUILD_VIEWER=OFF
 
       - name: Build
-        run: make -j
+        run: cmake --build build --parallel
 
       - name: Verify CLI
         run: ./build/bin/orbit-sim --help
@@ -60,14 +60,14 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
 
-      - name: Set up CMake
-        uses: lukka/get-cmake@latest
+      - name: Configure CMake
+        run: cmake -S . -B build -DBUILD_VIEWER=OFF
 
       - name: Build
-        run: make -j
+        run: cmake --build build --parallel
 
       - name: Validate system file
-        run: make validate
+        run: ./build/bin/orbit-sim validate --system systems/earth_moon.json
 
       - name: Run test simulation
-        run: make test
+        run: ./build/bin/orbit-sim run --system systems/earth_moon.json --steps 100 --dt 3600 --output results/test_out.csv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
 
       - name: Check changed files formatting
         run: |
-          git clang-format --diff HEAD~1 > format.patch
+          git fetch origin main
+          git clang-format origin/main > format.patch
           if [ -s format.patch ]; then
             echo "Formatting violations found:"
             cat format.patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install clang-format
-        run: sudo apt-get update && sudo apt-get install -y clang-format
+      - name: Install clang-format 21
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 21
+          sudo apt-get install -y clang-format-21
 
       - name: Check changed files formatting
         run: |
           git fetch origin main
-          git clang-format origin/main > format.patch
+          git clang-format-21 origin/main > format.patch
           if [ -s format.patch ]; then
             echo "Formatting violations found:"
             cat format.patch

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 !.github/
 !.github/**
 !CMakeLists.txt
+!Makefile
+!.clang-format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Option to enable / disable viewer (ON locally, OFF in CI)
-option(BUILD_VIEWER "Build OpenGL viewer" ON)
+option(BUILD_VIEWER "Build OpenGL viewer (requires OpenGL, GLFW, GLM)" ON)
 
 # Put all executables in build/bin
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -23,9 +23,14 @@ find_package(CURL REQUIRED)
 
 # Viewer-only dependencies (only searched if viewer enabled)
 if (BUILD_VIEWER)
-    find_package(OpenGL REQUIRED)
-    find_package(glfw3 REQUIRED)
-    find_package(glm REQUIRED)       # for matrices & vectors
+    find_package(OpenGL)
+    find_package(glfw3)
+    find_package(glm)
+
+    if (NOT OpenGL_FOUND OR NOT GLFW3_FOUND OR NOT GLM_FOUND)
+        message(WARNING "OpenGL, GLFW3, or GLM not found. Disabling viewer.")
+        set(BUILD_VIEWER OFF CACHE BOOL "Build OpenGL viewer" FORCE)
+    endif()
 endif()
 
 # ------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,225 @@
+# Makefile for Orbital Mechanics Engine
+# ======================================
+
+# Configuration
+BUILD_DIR        := build
+BUILD_VIEWER     ?= 1
+CMAKE_FLAGS      ?=
+CMAKE            := cmake
+CMAKE_CONFIG     := $(CMAKE) .. $(CMAKE_FLAGS) -DBUILD_VIEWER=$(BUILD_VIEWER)
+
+# Directories
+PROJECT_ROOT     := $(shell cd $(BUILD_DIR)/.. && pwd)
+SYSTEMS_DIR      := $(PROJECT_ROOT)/systems
+RESULTS_DIR      := $(PROJECT_ROOT)/results
+SCRIPTS_DIR      := $(PROJECT_ROOT)/plotting_scripts
+
+# Executables
+SIM_EXE          := $(BUILD_DIR)/bin/orbit-sim
+VIEWER_EXE       := $(BUILD_DIR)/bin/orbit-viewer
+
+# Default simulation parameters
+DEFAULT_SYSTEM   := $(SYSTEMS_DIR)/earth_moon.json
+DEFAULT_OUTPUT   := $(RESULTS_DIR)/out.csv
+DEFAULT_STEPS    := 500
+DEFAULT_DT       := 3600
+
+# Python
+PYTHON           := python3
+
+# Colors for help output
+BLUE             := \033[0;34m
+GREEN            := \033[0;32m
+YELLOW           := \033[0;33m
+NC               := \033[0m
+
+.PHONY: all build build-sim build-viewer clean reconfigure help
+.PHONY: run run-earth-moon run-solar-system view fetch validate validate-earth-moon test
+.PHONY: plot plot-energy plot-momentum plot-3d plot-3d-exaggerated plot-3d-earth-moon
+
+# Default target
+all: build
+
+# ========================================
+# BUILD TARGETS
+# ========================================
+
+build: $(BUILD_DIR)/Makefile
+	@echo "$(GREEN)Building project...$(NC)"
+	@$(MAKE) -C $(BUILD_DIR) -j$$(nproc)
+	@echo "$(GREEN)Build complete. Executables in $(BUILD_DIR)/bin/$(NC)"
+
+$(BUILD_DIR)/Makefile:
+	@echo "$(BLUE)Configuring project with CMake...$(NC)"
+	@mkdir -p $(BUILD_DIR)
+	@cd $(BUILD_DIR) && $(CMAKE_CONFIG)
+	@echo "$(GREEN)Configuration complete. Run 'make -C $(BUILD_DIR)' to build.$(NC)"
+
+build-sim: $(BUILD_DIR)/Makefile
+	@$(MAKE) -C $(BUILD_DIR) orbit-sim -j$$(nproc)
+
+build-viewer: $(BUILD_DIR)/Makefile
+	@$(MAKE) -C $(BUILD_DIR) orbit-viewer -j$$(nproc)
+
+clean:
+	@echo "$(YELLOW)Cleaning build directory...$(NC)"
+	@rm -rf $(BUILD_DIR)
+	@echo "$(GREEN)Clean complete.$(NC)"
+
+reconfigure:
+	@echo "$(BLUE)Reconfiguring project...$(NC)"
+	@rm -rf $(BUILD_DIR)
+	@mkdir -p $(BUILD_DIR)
+	@cd $(BUILD_DIR) && $(CMAKE_CONFIG)
+	@echo "$(GREEN)Reconfiguration complete.$(NC)"
+
+# ========================================
+# RUN TARGETS
+# ========================================
+
+run: $(SIM_EXE)
+	@$(SIM_EXE) run \
+		--system $(DEFAULT_SYSTEM) \
+		--steps $(DEFAULT_STEPS) \
+		--dt $(DEFAULT_DT) \
+		--output $(DEFAULT_OUTPUT)
+
+run-earth-moon: $(SIM_EXE)
+	@echo "$(BLUE)Running Earth-Moon simulation...$(NC)"
+	@mkdir -p $(RESULTS_DIR)
+	@$(SIM_EXE) run \
+		--system $(SYSTEMS_DIR)/earth_moon.json \
+		--steps $(DEFAULT_STEPS) \
+		--dt $(DEFAULT_DT) \
+		--output $(RESULTS_DIR)/earth_moon_out.csv
+	@echo "$(GREEN)Output: $(RESULTS_DIR)/earth_moon_out.csv$(NC)"
+
+run-solar-system: $(SIM_EXE)
+	@echo "$(BLUE)Running Solar System simulation (100k steps)...$(NC)"
+	@mkdir -p $(RESULTS_DIR)
+	@$(SIM_EXE) run \
+		--system $(SYSTEMS_DIR)/solar_system.json \
+		--steps 100000 \
+		--dt 3600 \
+		--output $(RESULTS_DIR)/solar_system_out.csv
+	@echo "$(GREEN)Output: $(RESULTS_DIR)/solar_system_out.csv$(NC)"
+
+view: $(VIEWER_EXE)
+	@$(VIEWER_EXE) $(DEFAULT_OUTPUT)
+
+view-last: $(VIEWER_EXE)
+	@$(VIEWER_EXE) $(RESULTS_DIR)/earth_moon_out.csv
+
+fetch:
+	@$(SIM_EXE) fetch \
+		--body 399 \
+		--center 0 \
+		--start 2025-01-01 \
+		--stop 2025-01-02 \
+		--step "6 h" \
+		--output $(RESULTS_DIR)/earth_ephem.txt
+
+validate: $(SIM_EXE)
+	@$(SIM_EXE) validate --system $(DEFAULT_SYSTEM)
+
+validate-earth-moon: $(SIM_EXE)
+	@$(SIM_EXE) validate --system $(SYSTEMS_DIR)/earth_moon.json
+
+test: validate-earth-moon
+	@echo "$(BLUE)Running quick simulation test...$(NC)"
+	@$(SIM_EXE) run \
+		--system $(SYSTEMS_DIR)/earth_moon.json \
+		--steps 100 \
+		--dt 3600 \
+		--output $(RESULTS_DIR)/test_out.csv
+	@echo "$(GREEN)Test complete. Output: $(RESULTS_DIR)/test_out.csv$(NC)"
+
+# ========================================
+# PYTHON PLOTTING TARGETS
+# ========================================
+
+plot: plot-energy plot-momentum plot-3d plot-3d-exaggerated plot-3d-earth-moon
+	@echo "$(GREEN)All plots generated.$(NC)"
+
+plot-energy:
+	@echo "$(BLUE)Generating energy conservation plot...$(NC)"
+	@cd $(SCRIPTS_DIR) && $(PYTHON) energy_conservation.py
+
+plot-momentum:
+	@echo "$(BLUE)Generating angular momentum plot...$(NC)"
+	@cd $(SCRIPTS_DIR) && $(PYTHON) angular_momentum_plot.py
+
+plot-3d:
+	@echo "$(BLUE)Generating 3D orbit plot...$(NC)"
+	@cd $(SCRIPTS_DIR) && $(PYTHON) 3Dplot.py
+
+plot-3d-exaggerated:
+	@echo "$(BLUE)Generating 3D exaggerated plot...$(NC)"
+	@cd $(SCRIPTS_DIR) && $(PYTHON) 3Dexaggerated_plot.py
+
+plot-3d-earth-moon:
+	@echo "$(BLUE)Generating Earth-Moon 3D plot...$(NC)"
+	@cd $(SCRIPTS_DIR) && $(PYTHON) 3Dplot_earth_moon.py
+
+# ========================================
+# HELP
+# ========================================
+
+help:
+	@echo ""
+	@echo "Orbital Mechanics Engine - Available Targets"
+	@echo "============================================"
+	@echo ""
+	@echo "  Build Targets:"
+	@echo "    make build              - Build all executables (default)"
+	@echo "    make build-sim          - Build orbit-sim only"
+	@echo "    make build-viewer       - Build orbit-viewer only"
+	@echo "    make clean              - Remove build directory"
+	@echo "    make reconfigure        - Clean and reconfigure CMake"
+	@echo ""
+	@echo "  Simulation Targets:"
+	@echo "    make run                - Run default simulation"
+	@echo "    make run-earth-moon     - Run Earth-Moon simulation"
+	@echo "    make run-solar-system   - Run full Solar System simulation"
+	@echo ""
+	@echo "  Viewer Targets:"
+	@echo "    make view               - Launch viewer with default output"
+	@echo "    make view-last          - Launch viewer with Earth-Moon output"
+	@echo ""
+	@echo "  Utility Targets:"
+	@echo "    make fetch              - Fetch HORIZONS ephemeris data"
+	@echo "    make validate           - Validate default system file"
+	@echo "    make validate-earth-moon - Validate Earth-Moon system file"
+	@echo "    make test               - Quick validation test"
+	@echo ""
+	@echo "  Python Plotting Targets:"
+	@echo "    make plot               - Generate all plots"
+	@echo "    make plot-energy        - Energy conservation plot"
+	@echo "    make plot-momentum      - Angular momentum plot"
+	@echo "    make plot-3d            - 3D orbit visualization"
+	@echo "    make plot-3d-exaggerated - 3D with exaggerated scale"
+	@echo "    make plot-3d-earth-moon - Earth-Moon 3D plot"
+	@echo ""
+	@echo "  Configuration Options:"
+	@echo "    BUILD_VIEWER=0          - Build without OpenGL viewer (CI/headless)"
+	@echo "    BUILD_VIEWER=1          - Build with OpenGL viewer (default)"
+	@echo "    CMAKE_FLAGS='...'       - Pass additional flags to CMake"
+	@echo ""
+	@echo "  Examples:"
+	@echo "    make build              # Normal build"
+	@echo "    make BUILD_VIEWER=0 build  # Headless build"
+	@echo "    make run-earth-moon    # Quick simulation"
+	@echo "    make view-last          # View results"
+	@echo ""
+	@echo "  Executables location: $(BUILD_DIR)/bin/"
+	@echo ""
+
+# ========================================
+# DEPENDENCY CHECKS
+# ========================================
+
+$(SIM_EXE): | $(BUILD_DIR)/Makefile
+	@$(MAKE) -C $(BUILD_DIR) orbit-sim
+
+$(VIEWER_EXE): | $(BUILD_DIR)/Makefile
+	@$(MAKE) -C $(BUILD_DIR) orbit-viewer

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ orbital-mechanics-engine/
 ├── shaders/               # GLSL shaders
 ├── docs/                  # Technical documentation
 ├── plotting_scripts/      # Python analysis tools
+├── Makefile              # Build orchestration
+├── .github/
+│   └── workflows/ci.yml  # CI pipeline
 ├── orbital_mechanics_engine_cli_reference.md  # CLI commands
 └── README.md
 ```
@@ -107,18 +110,73 @@ orbital-mechanics-engine/
 ### Requirements
 - C++17 compiler
 - CMake ≥ 3.14
-- OpenGL 3.3
+- OpenGL 3.3 (optional, for viewer)
 - GLAD
 - GLFW3
 - GLM (OpenGL Mathematics)
 - libcurl
 - Python 3 (optional, for plotting)
 
-### Build Steps
+### Quick Start with Makefile
 
 ```bash
 git clone https://github.com/eisensenpou/orbital-mechanics-engine.git
 cd orbital-mechanics-engine
+make
+```
+
+### Makefile Targets
+
+| Target | Description |
+|--------|-------------|
+| `make build` | Build all executables |
+| `make build-sim` | Build CLI only |
+| `make build-viewer` | Build viewer only |
+| `make clean` | Remove build directory |
+| `make reconfigure` | Clean and reconfigure CMake |
+
+**Simulation:**
+| Target | Description |
+|--------|-------------|
+| `make run` | Run default simulation |
+| `make run-earth-moon` | Run Earth-Moon simulation |
+| `make run-solar-system` | Run full Solar System (100k steps) |
+
+**Viewer:**
+| Target | Description |
+|--------|-------------|
+| `make view` | Launch viewer with default output |
+| `make view-last` | Launch viewer with Earth-Moon results |
+
+**Utilities:**
+| Target | Description |
+|--------|-------------|
+| `make validate` | Validate system file |
+| `make test` | Quick validation test |
+| `make fetch` | Fetch HORIZONS ephemeris |
+
+**Python Plotting:**
+| Target | Description |
+|--------|-------------|
+| `make plot` | Generate all plots |
+| `make plot-energy` | Energy conservation plot |
+| `make plot-momentum` | Angular momentum plot |
+| `make plot-3d` | 3D orbit visualization |
+| `make plot-3d-exaggerated` | 3D with exaggerated scale |
+
+### Configuration Options
+
+```bash
+# Build without OpenGL viewer (headless/CI)
+make BUILD_VIEWER=0 build
+
+# Pass custom CMake flags
+make CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug" build
+```
+
+### Manual Build Steps
+
+```bash
 mkdir build && cd build
 cmake ..
 make -j
@@ -126,8 +184,8 @@ make -j
 
 Executables appear in `build/bin/`:
 
-- `orbit-sim` — main simulation engine  
-- `orbit-viewer` — real‑time 3D visualization  
+- `orbit-sim` — main simulation engine
+- `orbit-viewer` — real‑time 3D visualization
 
 ---
 
@@ -274,6 +332,19 @@ The simulation employs a fourth-order Runge-Kutta (RK4) integrator for state pro
 - Limited to modest N-body counts (performance considerations)
 - No collision detection or handling
 - Simplified eclipse geometry (no atmospheric effects)
+
+---
+
+## 🔄 Continuous Integration
+
+The project uses GitHub Actions for CI on every push and pull request.
+
+**CI Pipeline:**
+1. **Lint** — Code formatting check (clang-format on changed files)
+2. **Build** — Compile release binary
+3. **Test** — Validate system files and run test simulations
+
+**Workflow:** `.github/workflows/ci.yml`
 
 ---
 

--- a/src/viewer/orbit_viewer.cpp
+++ b/src/viewer/orbit_viewer.cpp
@@ -27,8 +27,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include <GLFW/glfw3.h>
 #include <glad/glad.h>
+#include <GLFW/glfw3.h>
 
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp> // includes glm::infinitePerspective
@@ -52,18 +52,19 @@ static double g_lastMouseX = 0.0;
 static double g_lastMouseY = 0.0;
 
 // Camera target selection
-enum class CameraTarget {
-  Barycenter = 0,
-  Sun,
-  Mercury,
-  Venus,
-  Earth,
-  Moon,
-  Mars,
-  Jupiter,
-  Saturn,
-  Uranus,
-  Neptune
+enum class CameraTarget
+{
+    Barycenter = 0,
+    Sun,
+    Mercury,
+    Venus,
+    Earth,
+    Moon,
+    Mars,
+    Jupiter,
+    Saturn,
+    Uranus,
+    Neptune
 };
 
 static CameraTarget g_cameraTarget = CameraTarget::Barycenter;
@@ -86,12 +87,13 @@ static const float LEGEND_SIZE_PX = 14.0f; // base square size
 // N-body rendering data
 // --------------------------------------------------
 
-struct BodyRenderInfo {
-  std::string name;
-  glm::vec3 color;
-  float radius;                     // visual radius in GL units
-  std::vector<glm::vec3> positions; // per-frame positions in GL units
-  SphereMesh mesh;
+struct BodyRenderInfo
+{
+    std::string name;
+    glm::vec3 color;
+    float radius;                     // visual radius in GL units
+    std::vector<glm::vec3> positions; // per-frame positions in GL units
+    SphereMesh mesh;
 };
 
 static std::vector<BodyRenderInfo> g_bodies;
@@ -101,8 +103,8 @@ static size_t g_frameIndex = 0;
 
 // Forward declarations
 static void handleLegendClick(double mouseX, double mouseY);
-static glm::vec3 getBodyPos(const std::string &name);
-static bool initBodiesFromCSV(const std::string &path);
+static glm::vec3 getBodyPos(const std::string& name);
+static bool initBodiesFromCSV(const std::string& path);
 
 // --------------------------------------------------
 // Callbacks
@@ -110,10 +112,11 @@ static bool initBodiesFromCSV(const std::string &path);
 /**
  * @brief Handles window resize events by updating the viewport.
  */
-static void framebuffer_size_callback(GLFWwindow *, int w, int h) {
-  g_windowWidth = w;
-  g_windowHeight = h;
-  glViewport(0, 0, w, h);
+static void framebuffer_size_callback(GLFWwindow*, int w, int h)
+{
+    g_windowWidth = w;
+    g_windowHeight = h;
+    glViewport(0, 0, w, h);
 }
 
 /**
@@ -121,40 +124,46 @@ static void framebuffer_size_callback(GLFWwindow *, int w, int h) {
  *  - RMB press/release → start/stop camera rotation
  *  - LMB press on legend → change camera target
  */
-static void mouse_button_callback(GLFWwindow *win, int button, int action,
-                                  int /*mods*/) {
-  if (button == GLFW_MOUSE_BUTTON_RIGHT) {
-    if (action == GLFW_PRESS) {
-      g_mouseRotating = true;
-      glfwGetCursorPos(win, &g_lastMouseX, &g_lastMouseY);
-    } else if (action == GLFW_RELEASE) {
-      g_mouseRotating = false;
+static void mouse_button_callback(GLFWwindow* win, int button, int action, int /*mods*/)
+{
+    if (button == GLFW_MOUSE_BUTTON_RIGHT)
+    {
+        if (action == GLFW_PRESS)
+        {
+            g_mouseRotating = true;
+            glfwGetCursorPos(win, &g_lastMouseX, &g_lastMouseY);
+        }
+        else if (action == GLFW_RELEASE)
+        {
+            g_mouseRotating = false;
+        }
     }
-  }
 
-  if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS) {
-    double mx, my;
-    glfwGetCursorPos(win, &mx, &my);
-    handleLegendClick(mx, my);
-  }
+    if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS)
+    {
+        double mx, my;
+        glfwGetCursorPos(win, &mx, &my);
+        handleLegendClick(mx, my);
+    }
 }
 
 /**
  * @brief Handles cursor position changes for mouse rotation.
  */
-static void cursor_pos_callback(GLFWwindow *, double xpos, double ypos) {
-  if (!g_mouseRotating)
-    return;
-  double dx = xpos - g_lastMouseX;
-  double dy = ypos - g_lastMouseY;
+static void cursor_pos_callback(GLFWwindow*, double xpos, double ypos)
+{
+    if (!g_mouseRotating)
+        return;
+    double dx = xpos - g_lastMouseX;
+    double dy = ypos - g_lastMouseY;
 
-  g_lastMouseX = xpos;
-  g_lastMouseY = ypos;
+    g_lastMouseX = xpos;
+    g_lastMouseY = ypos;
 
-  g_yaw += static_cast<float>(dx) * 0.005f;
-  g_pitch -= static_cast<float>(dy) * 0.005f;
+    g_yaw += static_cast<float>(dx) * 0.005f;
+    g_pitch -= static_cast<float>(dy) * 0.005f;
 
-  g_pitch = glm::clamp(g_pitch, glm::radians(-89.0f), glm::radians(89.0f));
+    g_pitch = glm::clamp(g_pitch, glm::radians(-89.0f), glm::radians(89.0f));
 }
 
 /**
@@ -162,10 +171,11 @@ static void cursor_pos_callback(GLFWwindow *, double xpos, double ypos) {
  *        Zoom speed adapts to current radius so inner / outer system feel
  * usable.
  */
-static void scroll_callback(GLFWwindow *, double /*xoff*/, double yoff) {
-  float zoomSpeed = std::max(0.0000005f, g_radius * 0.1f);
-  g_radius -= static_cast<float>(yoff) * zoomSpeed;
-  g_radius = glm::clamp(g_radius, 0.00000001f, 100000.0f);
+static void scroll_callback(GLFWwindow*, double /*xoff*/, double yoff)
+{
+    float zoomSpeed = std::max(0.0000005f, g_radius * 0.1f);
+    g_radius -= static_cast<float>(yoff) * zoomSpeed;
+    g_radius = glm::clamp(g_radius, 0.00000001f, 100000.0f);
 }
 
 /**
@@ -173,45 +183,46 @@ static void scroll_callback(GLFWwindow *, double /*xoff*/, double yoff) {
  *  1 = Sun, 2 = Mercury, 3 = Venus, 4 = Earth, 5 = Moon,
  *  6 = Mars, 7 = Jupiter, 8 = Saturn, 9 = Uranus, 0 = Neptune
  */
-static void key_callback(GLFWwindow * /*win*/, int key, int /*scancode*/,
-                         int action, int /*mods*/) {
-  if (action != GLFW_PRESS)
-    return;
+static void key_callback(GLFWwindow* /*win*/, int key, int /*scancode*/, int action, int /*mods*/)
+{
+    if (action != GLFW_PRESS)
+        return;
 
-  switch (key) {
-  case GLFW_KEY_1:
-    g_cameraTarget = CameraTarget::Sun;
-    break;
-  case GLFW_KEY_2:
-    g_cameraTarget = CameraTarget::Mercury;
-    break;
-  case GLFW_KEY_3:
-    g_cameraTarget = CameraTarget::Venus;
-    break;
-  case GLFW_KEY_4:
-    g_cameraTarget = CameraTarget::Earth;
-    break;
-  case GLFW_KEY_5:
-    g_cameraTarget = CameraTarget::Moon;
-    break;
-  case GLFW_KEY_6:
-    g_cameraTarget = CameraTarget::Mars;
-    break;
-  case GLFW_KEY_7:
-    g_cameraTarget = CameraTarget::Jupiter;
-    break;
-  case GLFW_KEY_8:
-    g_cameraTarget = CameraTarget::Saturn;
-    break;
-  case GLFW_KEY_9:
-    g_cameraTarget = CameraTarget::Uranus;
-    break;
-  case GLFW_KEY_0:
-    g_cameraTarget = CameraTarget::Neptune;
-    break;
-  default:
-    break;
-  }
+    switch (key)
+    {
+    case GLFW_KEY_1:
+        g_cameraTarget = CameraTarget::Sun;
+        break;
+    case GLFW_KEY_2:
+        g_cameraTarget = CameraTarget::Mercury;
+        break;
+    case GLFW_KEY_3:
+        g_cameraTarget = CameraTarget::Venus;
+        break;
+    case GLFW_KEY_4:
+        g_cameraTarget = CameraTarget::Earth;
+        break;
+    case GLFW_KEY_5:
+        g_cameraTarget = CameraTarget::Moon;
+        break;
+    case GLFW_KEY_6:
+        g_cameraTarget = CameraTarget::Mars;
+        break;
+    case GLFW_KEY_7:
+        g_cameraTarget = CameraTarget::Jupiter;
+        break;
+    case GLFW_KEY_8:
+        g_cameraTarget = CameraTarget::Saturn;
+        break;
+    case GLFW_KEY_9:
+        g_cameraTarget = CameraTarget::Uranus;
+        break;
+    case GLFW_KEY_0:
+        g_cameraTarget = CameraTarget::Neptune;
+        break;
+    default:
+        break;
+    }
 }
 
 // --------------------------------------------------
@@ -220,48 +231,52 @@ static void key_callback(GLFWwindow * /*win*/, int key, int /*scancode*/,
 /**
  * @brief Compiles a shader of given type from source code.
  */
-static GLuint compileShader(GLenum type, const char *src) {
-  GLuint s = glCreateShader(type);
-  glShaderSource(s, 1, &src, nullptr);
-  glCompileShader(s);
+static GLuint compileShader(GLenum type, const char* src)
+{
+    GLuint s = glCreateShader(type);
+    glShaderSource(s, 1, &src, nullptr);
+    glCompileShader(s);
 
-  GLint ok = 0;
-  glGetShaderiv(s, GL_COMPILE_STATUS, &ok);
-  if (!ok) {
-    GLint len = 0;
-    glGetShaderiv(s, GL_INFO_LOG_LENGTH, &len);
-    std::string log(len, '\0');
-    glGetShaderInfoLog(s, len, nullptr, log.data());
-    std::cerr << "❌ Shader error:\n" << log << "\n";
-  }
-  return s;
+    GLint ok = 0;
+    glGetShaderiv(s, GL_COMPILE_STATUS, &ok);
+    if (!ok)
+    {
+        GLint len = 0;
+        glGetShaderiv(s, GL_INFO_LOG_LENGTH, &len);
+        std::string log(len, '\0');
+        glGetShaderInfoLog(s, len, nullptr, log.data());
+        std::cerr << "❌ Shader error:\n" << log << "\n";
+    }
+    return s;
 }
 
 /**
  * @brief Creates an OpenGL program from a vertex + fragment shader pair.
  */
-static GLuint createProgram(const char *vsSrc, const char *fsSrc) {
-  GLuint vs = compileShader(GL_VERTEX_SHADER, vsSrc);
-  GLuint fs = compileShader(GL_FRAGMENT_SHADER, fsSrc);
+static GLuint createProgram(const char* vsSrc, const char* fsSrc)
+{
+    GLuint vs = compileShader(GL_VERTEX_SHADER, vsSrc);
+    GLuint fs = compileShader(GL_FRAGMENT_SHADER, fsSrc);
 
-  GLuint prog = glCreateProgram();
-  glAttachShader(prog, vs);
-  glAttachShader(prog, fs);
-  glLinkProgram(prog);
+    GLuint prog = glCreateProgram();
+    glAttachShader(prog, vs);
+    glAttachShader(prog, fs);
+    glLinkProgram(prog);
 
-  GLint ok = 0;
-  glGetProgramiv(prog, GL_LINK_STATUS, &ok);
-  if (!ok) {
-    GLint len = 0;
-    glGetProgramiv(prog, GL_INFO_LOG_LENGTH, &len);
-    std::string log(len, '\0');
-    glGetProgramInfoLog(prog, len, nullptr, log.data());
-    std::cerr << "❌ Link error:\n" << log << "\n";
-  }
+    GLint ok = 0;
+    glGetProgramiv(prog, GL_LINK_STATUS, &ok);
+    if (!ok)
+    {
+        GLint len = 0;
+        glGetProgramiv(prog, GL_INFO_LOG_LENGTH, &len);
+        std::string log(len, '\0');
+        glGetProgramInfoLog(prog, len, nullptr, log.data());
+        std::cerr << "❌ Link error:\n" << log << "\n";
+    }
 
-  glDeleteShader(vs);
-  glDeleteShader(fs);
-  return prog;
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+    return prog;
 }
 
 // --------------------------------------------------
@@ -273,8 +288,9 @@ static GLuint createProgram(const char *vsSrc, const char *fsSrc) {
  *
  * Draws small colored squares in NDC that we then place in pixel space.
  */
-static void initLegendRenderer() {
-  const char *legendVs = R"GLSL(
+static void initLegendRenderer()
+{
+    const char* legendVs = R"GLSL(
         #version 330 core
         layout(location = 0) in vec2 aPos;
 
@@ -287,7 +303,7 @@ static void initLegendRenderer() {
         }
     )GLSL";
 
-  const char *legendFs = R"GLSL(
+    const char* legendFs = R"GLSL(
         #version 330 core
         out vec4 FragColor;
         uniform vec3 uColor;
@@ -297,29 +313,29 @@ static void initLegendRenderer() {
         }
     )GLSL";
 
-  g_legendShader = createProgram(legendVs, legendFs);
+    g_legendShader = createProgram(legendVs, legendFs);
 
-  g_legLocOffset = glGetUniformLocation(g_legendShader, "uOffset");
-  g_legLocScale = glGetUniformLocation(g_legendShader, "uScale");
-  g_legLocColor = glGetUniformLocation(g_legendShader, "uColor");
+    g_legLocOffset = glGetUniformLocation(g_legendShader, "uOffset");
+    g_legLocScale = glGetUniformLocation(g_legendShader, "uScale");
+    g_legLocColor = glGetUniformLocation(g_legendShader, "uColor");
 
-  // Unit square centered at origin, two triangles
-  float quadVerts[] = {-0.5f, -0.5f, 0.5f, -0.5f, 0.5f,  0.5f,
+    // Unit square centered at origin, two triangles
+    float quadVerts[] = {-0.5f, -0.5f, 0.5f, -0.5f, 0.5f,  0.5f,
 
-                       -0.5f, -0.5f, 0.5f, 0.5f,  -0.5f, 0.5f};
+                         -0.5f, -0.5f, 0.5f, 0.5f,  -0.5f, 0.5f};
 
-  glGenVertexArrays(1, &g_legendVAO);
-  glGenBuffers(1, &g_legendVBO);
+    glGenVertexArrays(1, &g_legendVAO);
+    glGenBuffers(1, &g_legendVBO);
 
-  glBindVertexArray(g_legendVAO);
-  glBindBuffer(GL_ARRAY_BUFFER, g_legendVBO);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(quadVerts), quadVerts, GL_STATIC_DRAW);
+    glBindVertexArray(g_legendVAO);
+    glBindBuffer(GL_ARRAY_BUFFER, g_legendVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(quadVerts), quadVerts, GL_STATIC_DRAW);
 
-  glEnableVertexAttribArray(0);
-  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), (void *)0);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), (void*)0);
 
-  glBindVertexArray(0);
-  glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 /**
@@ -330,66 +346,70 @@ static void initLegendRenderer() {
  * @param sizePx    Square size in pixels.
  * @param color     RGB color.
  */
-static void drawLegendBox(float centerPx, float centerPy, float sizePx,
-                          const glm::vec3 &color) {
-  if (g_windowWidth <= 0 || g_windowHeight <= 0)
-    return;
+static void drawLegendBox(float centerPx, float centerPy, float sizePx, const glm::vec3& color)
+{
+    if (g_windowWidth <= 0 || g_windowHeight <= 0)
+        return;
 
-  // Convert center in pixels → NDC
-  float x_ndc = 2.0f * centerPx / static_cast<float>(g_windowWidth) - 1.0f;
-  float y_ndc = 1.0f - 2.0f * centerPy / static_cast<float>(g_windowHeight);
+    // Convert center in pixels → NDC
+    float x_ndc = 2.0f * centerPx / static_cast<float>(g_windowWidth) - 1.0f;
+    float y_ndc = 1.0f - 2.0f * centerPy / static_cast<float>(g_windowHeight);
 
-  // Convert size in pixels → NDC scale (quad is [-0.5..0.5])
-  float sx = sizePx / static_cast<float>(g_windowWidth) * 2.0f;
-  float sy = sizePx / static_cast<float>(g_windowHeight) * 2.0f;
+    // Convert size in pixels → NDC scale (quad is [-0.5..0.5])
+    float sx = sizePx / static_cast<float>(g_windowWidth) * 2.0f;
+    float sy = sizePx / static_cast<float>(g_windowHeight) * 2.0f;
 
-  glUseProgram(g_legendShader);
-  glUniform2f(g_legLocOffset, x_ndc, y_ndc);
-  glUniform2f(g_legLocScale, sx, sy);
-  glUniform3fv(g_legLocColor, 1, glm::value_ptr(color));
+    glUseProgram(g_legendShader);
+    glUniform2f(g_legLocOffset, x_ndc, y_ndc);
+    glUniform2f(g_legLocScale, sx, sy);
+    glUniform3fv(g_legLocColor, 1, glm::value_ptr(color));
 
-  glBindVertexArray(g_legendVAO);
-  glDrawArrays(GL_TRIANGLES, 0, 6);
-  glBindVertexArray(0);
+    glBindVertexArray(g_legendVAO);
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+    glBindVertexArray(0);
 }
 
 /**
  * @brief Handle a left-click; if it lands on a legend box,
  *        update camera target (Sun/Earth/Moon).
  */
-static void handleLegendClick(double mouseX, double mouseY) {
-  // Legend row centers in pixels
-  float centersY[3] = {LEGEND_BASE_Y, LEGEND_BASE_Y + LEGEND_SPACING,
-                       LEGEND_BASE_Y + 2.0f * LEGEND_SPACING};
+static void handleLegendClick(double mouseX, double mouseY)
+{
+    // Legend row centers in pixels
+    float centersY[3] = {LEGEND_BASE_Y, LEGEND_BASE_Y + LEGEND_SPACING,
+                         LEGEND_BASE_Y + 2.0f * LEGEND_SPACING};
 
-  float halfSize = LEGEND_SIZE_PX * 0.5f;
-  float x0 = LEGEND_BASE_X - halfSize;
-  float x1 = LEGEND_BASE_X + halfSize;
+    float halfSize = LEGEND_SIZE_PX * 0.5f;
+    float x0 = LEGEND_BASE_X - halfSize;
+    float x1 = LEGEND_BASE_X + halfSize;
 
-  for (int i = 0; i < 3; ++i) {
-    float yCenter = centersY[i];
-    float y0 = yCenter - halfSize;
-    float y1 = yCenter + halfSize;
+    for (int i = 0; i < 3; ++i)
+    {
+        float yCenter = centersY[i];
+        float y0 = yCenter - halfSize;
+        float y1 = yCenter + halfSize;
 
-    if (mouseX >= x0 && mouseX <= x1 && mouseY >= y0 && mouseY <= y1) {
+        if (mouseX >= x0 && mouseX <= x1 && mouseY >= y0 && mouseY <= y1)
+        {
 
-      switch (i) {
-      case 0:
-        g_cameraTarget = CameraTarget::Sun;
-        break;
-      case 1:
-        g_cameraTarget = CameraTarget::Earth;
-        break;
-      case 2:
-        g_cameraTarget = CameraTarget::Moon;
-        break;
-      }
+            switch (i)
+            {
+            case 0:
+                g_cameraTarget = CameraTarget::Sun;
+                break;
+            case 1:
+                g_cameraTarget = CameraTarget::Earth;
+                break;
+            case 2:
+                g_cameraTarget = CameraTarget::Moon;
+                break;
+            }
 
-      std::cout << "📌 Camera target set to "
-                << (i == 0 ? "Sun" : (i == 1 ? "Earth" : "Moon")) << "\n";
-      return;
+            std::cout << "📌 Camera target set to "
+                      << (i == 0 ? "Sun" : (i == 1 ? "Earth" : "Moon")) << "\n";
+            return;
+        }
     }
-  }
 }
 
 // --------------------------------------------------
@@ -409,73 +429,76 @@ static constexpr float DIST_VIS_SCALE = 0.02f;
 static constexpr float MOON_EXAGGERATION = 15.0f;
 
 // Color map for Solar System bodies
-static glm::vec3 colorForBody(const std::string &name) {
-  if (name == "Sun")
-    return {1.4f, 1.1f, 0.3f};
-  if (name == "Mercury")
-    return {0.7f, 0.7f, 0.7f};
-  if (name == "Venus")
-    return {1.0f, 0.9f, 0.6f};
-  if (name == "Earth")
-    return {0.2f, 0.8f, 1.2f};
-  if (name == "Moon")
-    return {0.85f, 0.85f, 0.92f};
-  if (name == "Mars")
-    return {0.9f, 0.3f, 0.2f};
-  if (name == "Jupiter")
-    return {1.0f, 0.7f, 0.4f};
-  if (name == "Saturn")
-    return {1.0f, 0.8f, 0.5f};
-  if (name == "Uranus")
-    return {0.5f, 0.8f, 1.0f};
-  if (name == "Neptune")
-    return {0.3f, 0.4f, 1.0f};
-  return {1.0f, 1.0f, 1.0f};
+static glm::vec3 colorForBody(const std::string& name)
+{
+    if (name == "Sun")
+        return {1.4f, 1.1f, 0.3f};
+    if (name == "Mercury")
+        return {0.7f, 0.7f, 0.7f};
+    if (name == "Venus")
+        return {1.0f, 0.9f, 0.6f};
+    if (name == "Earth")
+        return {0.2f, 0.8f, 1.2f};
+    if (name == "Moon")
+        return {0.85f, 0.85f, 0.92f};
+    if (name == "Mars")
+        return {0.9f, 0.3f, 0.2f};
+    if (name == "Jupiter")
+        return {1.0f, 0.7f, 0.4f};
+    if (name == "Saturn")
+        return {1.0f, 0.8f, 0.5f};
+    if (name == "Uranus")
+        return {0.5f, 0.8f, 1.0f};
+    if (name == "Neptune")
+        return {0.3f, 0.4f, 1.0f};
+    return {1.0f, 1.0f, 1.0f};
 }
 
 // Physical radii in meters → GL units (no exaggeration)
-static float radiusForBody(const std::string &name) {
-  float r_m = 6.0e6f; // default ~Earth-sized as fallback
+static float radiusForBody(const std::string& name)
+{
+    float r_m = 6.0e6f; // default ~Earth-sized as fallback
 
-  if (name == "Sun")
-    r_m = 6.9634e8f;
-  else if (name == "Mercury")
-    r_m = 2.4397e6f;
-  else if (name == "Venus")
-    r_m = 6.0518e6f;
-  else if (name == "Earth")
-    r_m = 6.3710e6f;
-  else if (name == "Moon")
-    r_m = 1.7374e6f;
-  else if (name == "Mars")
-    r_m = 3.3895e6f;
-  else if (name == "Jupiter")
-    r_m = 6.9911e7f;
-  else if (name == "Saturn")
-    r_m = 5.8232e7f;
-  else if (name == "Uranus")
-    r_m = 2.5362e7f;
-  else if (name == "Neptune")
-    r_m = 2.4622e7f;
+    if (name == "Sun")
+        r_m = 6.9634e8f;
+    else if (name == "Mercury")
+        r_m = 2.4397e6f;
+    else if (name == "Venus")
+        r_m = 6.0518e6f;
+    else if (name == "Earth")
+        r_m = 6.3710e6f;
+    else if (name == "Moon")
+        r_m = 1.7374e6f;
+    else if (name == "Mars")
+        r_m = 3.3895e6f;
+    else if (name == "Jupiter")
+        r_m = 6.9911e7f;
+    else if (name == "Saturn")
+        r_m = 5.8232e7f;
+    else if (name == "Uranus")
+        r_m = 2.5362e7f;
+    else if (name == "Neptune")
+        r_m = 2.4622e7f;
 
-  // meters → GL units (no extra radius exaggeration)
-  return r_m * DIST_SCALE_METERS;
+    // meters → GL units (no extra radius exaggeration)
+    return r_m * DIST_SCALE_METERS;
 }
 
 /**
  * @brief Returns the current position of a body (in GL units) for the active
  * frame. If body is missing or has no data, returns (0,0,0).
  */
-static glm::vec3 getBodyPos(const std::string &name) {
-  auto it = g_bodyIndex.find(name);
-  if (it == g_bodyIndex.end())
-    return glm::vec3(0.0f);
-  size_t idx = it->second;
-  if (g_bodies.empty() || g_bodies[idx].positions.empty())
-    return glm::vec3(0.0f);
+static glm::vec3 getBodyPos(const std::string& name)
+{
+    auto it = g_bodyIndex.find(name);
+    if (it == g_bodyIndex.end())
+        return glm::vec3(0.0f);
+    size_t idx = it->second;
+    if (g_bodies.empty() || g_bodies[idx].positions.empty())
+        return glm::vec3(0.0f);
 
-  size_t frame = (g_numFrames == 0) ? 0 : (g_frameIndex % g_numFrames);
-  return g_bodies[idx].positions[frame];
+    size_t frame = (g_numFrames == 0) ? 0 : (g_frameIndex % g_numFrames);
+    return g_bodies[idx].positions[frame];
 }
 
 /**
@@ -485,128 +508,145 @@ static glm::vec3 getBodyPos(const std::string &name) {
  *        - Compresses distances (2%) for visibility
  *        - Optionally exaggerates Moon orbit for visibility
  */
-static bool initBodiesFromCSV(const std::string &path) {
-  std::ifstream file(path);
-  if (!file.is_open()) {
-    std::cerr << "❌ Could not open CSV: " << path << "\n";
-    return false;
-  }
-
-  std::string line;
-  if (!std::getline(file, line)) {
-    std::cerr << "⚠️ Empty CSV: " << path << "\n";
-    return false;
-  }
-
-  std::stringstream header(line);
-  std::vector<std::string> columns;
-  std::string col;
-  while (std::getline(header, col, ',')) {
-    columns.push_back(col);
-  }
-
-  // Identify body columns: x_name,y_name,z_name groups.
-  struct Triplet {
-    int ix, iy, iz;
-  };
-  std::vector<Triplet> bodyCols;
-
-  for (size_t i = 0; i + 2 < columns.size(); ++i) {
-    if (columns[i].rfind("x_", 0) == 0) {
-      std::string name = columns[i].substr(2);
-      int ix = static_cast<int>(i);
-      int iy = static_cast<int>(i + 1);
-      int iz = static_cast<int>(i + 2);
-
-      BodyRenderInfo body;
-      body.name = name;
-      body.color = colorForBody(name);
-      body.radius = radiusForBody(name);
-
-      g_bodyIndex[name] = static_cast<size_t>(g_bodies.size());
-      g_bodies.push_back(std::move(body));
-      bodyCols.push_back({ix, iy, iz});
-    }
-  }
-
-  if (g_bodies.empty()) {
-    std::cerr << "⚠️ No x_* body columns found in CSV header.\n";
-    return false;
-  }
-
-  constexpr float SCALE_METERS = DIST_SCALE_METERS;
-
-  size_t lineCount = 0;
-  while (std::getline(file, line)) {
-    if (line.empty())
-      continue;
-    std::stringstream ss(line);
-    std::vector<double> rowValues;
-    std::string v;
-    while (std::getline(ss, v, ',')) {
-      try {
-        rowValues.push_back(std::stod(v));
-      } catch (...) {
-        rowValues.push_back(0.0);
-      }
+static bool initBodiesFromCSV(const std::string& path)
+{
+    std::ifstream file(path);
+    if (!file.is_open())
+    {
+        std::cerr << "❌ Could not open CSV: " << path << "\n";
+        return false;
     }
 
-    if (rowValues.size() < columns.size()) {
-      // malformed row, skip
-      continue;
+    std::string line;
+    if (!std::getline(file, line))
+    {
+        std::cerr << "⚠️ Empty CSV: " << path << "\n";
+        return false;
     }
 
-    // Per-frame positions for all bodies (scaled).
-    std::vector<glm::vec3> framePos(g_bodies.size(), glm::vec3(0.0f));
-
-    // First, load raw scaled positions.
-    for (size_t bi = 0; bi < g_bodies.size(); ++bi) {
-      const auto &trips = bodyCols[bi];
-      double x = rowValues[trips.ix];
-      double y = rowValues[trips.iy];
-      double z = rowValues[trips.iz];
-
-      glm::vec3 p(static_cast<float>(x * SCALE_METERS),
-                  static_cast<float>(y * SCALE_METERS),
-                  static_cast<float>(z * SCALE_METERS));
-
-      // ----------------------------------------
-      // ✨ VISUAL DISTANCE COMPRESSION (2%)
-      // ----------------------------------------
-      // This keeps all orbital shapes and relative geometry,
-      // but pulls the whole system closer to the camera so
-      // Jupiter / Saturn / Uranus / Neptune are actually visible.
-      p *= DIST_VIS_SCALE;
-
-      framePos[bi] = p;
+    std::stringstream header(line);
+    std::vector<std::string> columns;
+    std::string col;
+    while (std::getline(header, col, ','))
+    {
+        columns.push_back(col);
     }
 
-    // Exaggerate Moon orbit if both Earth and Moon exist.
-    if (MOON_EXAGGERATION != 1.0f) {
-      auto itEarth = g_bodyIndex.find("Earth");
-      auto itMoon = g_bodyIndex.find("Moon");
-      if (itEarth != g_bodyIndex.end() && itMoon != g_bodyIndex.end()) {
-        size_t eIdx = itEarth->second;
-        size_t mIdx = itMoon->second;
-        glm::vec3 earthPos = framePos[eIdx];
-        glm::vec3 moonPos = framePos[mIdx];
-        glm::vec3 offset = moonPos - earthPos;
-        framePos[mIdx] = earthPos + offset * MOON_EXAGGERATION;
-      }
+    // Identify body columns: x_name,y_name,z_name groups.
+    struct Triplet
+    {
+        int ix, iy, iz;
+    };
+    std::vector<Triplet> bodyCols;
+
+    for (size_t i = 0; i + 2 < columns.size(); ++i)
+    {
+        if (columns[i].rfind("x_", 0) == 0)
+        {
+            std::string name = columns[i].substr(2);
+            int ix = static_cast<int>(i);
+            int iy = static_cast<int>(i + 1);
+            int iz = static_cast<int>(i + 2);
+
+            BodyRenderInfo body;
+            body.name = name;
+            body.color = colorForBody(name);
+            body.radius = radiusForBody(name);
+
+            g_bodyIndex[name] = static_cast<size_t>(g_bodies.size());
+            g_bodies.push_back(std::move(body));
+            bodyCols.push_back({ix, iy, iz});
+        }
     }
 
-    // Append frame positions to each body.
-    for (size_t bi = 0; bi < g_bodies.size(); ++bi) {
-      g_bodies[bi].positions.push_back(framePos[bi]);
+    if (g_bodies.empty())
+    {
+        std::cerr << "⚠️ No x_* body columns found in CSV header.\n";
+        return false;
     }
 
-    ++lineCount;
-  }
+    constexpr float SCALE_METERS = DIST_SCALE_METERS;
 
-  g_numFrames = lineCount;
-  std::cout << "📄 Loaded " << g_numFrames << " frames for " << g_bodies.size()
-            << " bodies from " << path << "\n";
-  return (g_numFrames > 0);
+    size_t lineCount = 0;
+    while (std::getline(file, line))
+    {
+        if (line.empty())
+            continue;
+        std::stringstream ss(line);
+        std::vector<double> rowValues;
+        std::string v;
+        while (std::getline(ss, v, ','))
+        {
+            try
+            {
+                rowValues.push_back(std::stod(v));
+            }
+            catch (...)
+            {
+                rowValues.push_back(0.0);
+            }
+        }
+
+        if (rowValues.size() < columns.size())
+        {
+            // malformed row, skip
+            continue;
+        }
+
+        // Per-frame positions for all bodies (scaled).
+        std::vector<glm::vec3> framePos(g_bodies.size(), glm::vec3(0.0f));
+
+        // First, load raw scaled positions.
+        for (size_t bi = 0; bi < g_bodies.size(); ++bi)
+        {
+            const auto& trips = bodyCols[bi];
+            double x = rowValues[trips.ix];
+            double y = rowValues[trips.iy];
+            double z = rowValues[trips.iz];
+
+            glm::vec3 p(static_cast<float>(x * SCALE_METERS), static_cast<float>(y * SCALE_METERS),
+                        static_cast<float>(z * SCALE_METERS));
+
+            // ----------------------------------------
+            // ✨ VISUAL DISTANCE COMPRESSION (2%)
+            // ----------------------------------------
+            // This keeps all orbital shapes and relative geometry,
+            // but pulls the whole system closer to the camera so
+            // Jupiter / Saturn / Uranus / Neptune are actually visible.
+            p *= DIST_VIS_SCALE;
+
+            framePos[bi] = p;
+        }
+
+        // Exaggerate Moon orbit if both Earth and Moon exist.
+        if (MOON_EXAGGERATION != 1.0f)
+        {
+            auto itEarth = g_bodyIndex.find("Earth");
+            auto itMoon = g_bodyIndex.find("Moon");
+            if (itEarth != g_bodyIndex.end() && itMoon != g_bodyIndex.end())
+            {
+                size_t eIdx = itEarth->second;
+                size_t mIdx = itMoon->second;
+                glm::vec3 earthPos = framePos[eIdx];
+                glm::vec3 moonPos = framePos[mIdx];
+                glm::vec3 offset = moonPos - earthPos;
+                framePos[mIdx] = earthPos + offset * MOON_EXAGGERATION;
+            }
+        }
+
+        // Append frame positions to each body.
+        for (size_t bi = 0; bi < g_bodies.size(); ++bi)
+        {
+            g_bodies[bi].positions.push_back(framePos[bi]);
+        }
+
+        ++lineCount;
+    }
+
+    g_numFrames = lineCount;
+    std::cout << "📄 Loaded " << g_numFrames << " frames for " << g_bodies.size() << " bodies from "
+              << path << "\n";
+    return (g_numFrames > 0);
 }
 
 // --------------------------------------------------
@@ -615,57 +655,62 @@ static bool initBodiesFromCSV(const std::string &path) {
 /**
  * @brief Entry point for the Orbit Viewer application.
  */
-int main() {
-  // Init N-body positions first (Solar System) from simulation output
-  if (!initBodiesFromCSV("./build/orbit_three_body.csv")) {
-    return -1;
-  }
+int main()
+{
+    // Init N-body positions first (Solar System) from simulation output
+    if (!initBodiesFromCSV("./build/orbit_three_body.csv"))
+    {
+        return -1;
+    }
 
-  // ----------------- GLFW init -----------------
-  if (!glfwInit()) {
-    std::cerr << "❌ Failed to init GLFW\n";
-    return -1;
-  }
+    // ----------------- GLFW init -----------------
+    if (!glfwInit())
+    {
+        std::cerr << "❌ Failed to init GLFW\n";
+        return -1;
+    }
 
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
-  GLFWwindow *win =
-      glfwCreateWindow(g_windowWidth, g_windowHeight,
-                       "Orbit Viewer (Solar System N-body)", nullptr, nullptr);
+    GLFWwindow* win = glfwCreateWindow(g_windowWidth, g_windowHeight,
+                                       "Orbit Viewer (Solar System N-body)", nullptr, nullptr);
 
-  if (!win) {
-    std::cerr << "❌ Failed to create window\n";
-    glfwTerminate();
-    return -1;
-  }
+    if (!win)
+    {
+        std::cerr << "❌ Failed to create window\n";
+        glfwTerminate();
+        return -1;
+    }
 
-  glfwMakeContextCurrent(win);
-  glfwSetFramebufferSizeCallback(win, framebuffer_size_callback);
-  glfwSetMouseButtonCallback(win, mouse_button_callback);
-  glfwSetCursorPosCallback(win, cursor_pos_callback);
-  glfwSetScrollCallback(win, scroll_callback);
-  glfwSetKeyCallback(win, key_callback);
+    glfwMakeContextCurrent(win);
+    glfwSetFramebufferSizeCallback(win, framebuffer_size_callback);
+    glfwSetMouseButtonCallback(win, mouse_button_callback);
+    glfwSetCursorPosCallback(win, cursor_pos_callback);
+    glfwSetScrollCallback(win, scroll_callback);
+    glfwSetKeyCallback(win, key_callback);
 
-  if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
-    std::cerr << "❌ Failed to init GLAD\n";
-    glfwDestroyWindow(win);
-    glfwTerminate();
-    return -1;
-  }
+    if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress))
+    {
+        std::cerr << "❌ Failed to init GLAD\n";
+        glfwDestroyWindow(win);
+        glfwTerminate();
+        return -1;
+    }
 
-  glEnable(GL_DEPTH_TEST);
+    glEnable(GL_DEPTH_TEST);
 
-  // Build sphere meshes for all bodies now that we have a valid GL context
-  for (auto &body : g_bodies) {
-    body.mesh.build(body.radius, 32, 32);
-  }
+    // Build sphere meshes for all bodies now that we have a valid GL context
+    for (auto& body : g_bodies)
+    {
+        body.mesh.build(body.radius, 32, 32);
+    }
 
-  // ----------------------------------------------------
-  // Create main 3D shader (Option C lighting)
-  // ----------------------------------------------------
-  const char *vsSrc = R"GLSL(
+    // ----------------------------------------------------
+    // Create main 3D shader (Option C lighting)
+    // ----------------------------------------------------
+    const char* vsSrc = R"GLSL(
         #version 330 core
         layout(location = 0) in vec3 aPos;
         layout(location = 1) in vec3 aNormal;
@@ -684,7 +729,7 @@ int main() {
         }
     )GLSL";
 
-  const char *fsSrc = R"GLSL(
+    const char* fsSrc = R"GLSL(
         #version 330 core
 
         in vec3 vNormal;
@@ -723,150 +768,149 @@ int main() {
         }
     )GLSL";
 
-  GLuint shader = createProgram(vsSrc, fsSrc);
-  GLint locMVP = glGetUniformLocation(shader, "uMVP");
-  GLint locModel = glGetUniformLocation(shader, "uModel");
-  GLint locColor = glGetUniformLocation(shader, "uColor");
-  GLint locLight = glGetUniformLocation(shader, "uLightPos");
-  GLint locViewPos = glGetUniformLocation(shader, "uViewPos");
+    GLuint shader = createProgram(vsSrc, fsSrc);
+    GLint locMVP = glGetUniformLocation(shader, "uMVP");
+    GLint locModel = glGetUniformLocation(shader, "uModel");
+    GLint locColor = glGetUniformLocation(shader, "uColor");
+    GLint locLight = glGetUniformLocation(shader, "uLightPos");
+    GLint locViewPos = glGetUniformLocation(shader, "uViewPos");
 
-  // ----------------------------------------------------
-  // Init legend renderer (2D colored boxes in NDC)
-  // ----------------------------------------------------
-  initLegendRenderer();
+    // ----------------------------------------------------
+    // Init legend renderer (2D colored boxes in NDC)
+    // ----------------------------------------------------
+    initLegendRenderer();
 
-  // ----------------------------------------------------
-  // Main render loop
-  // ----------------------------------------------------
-  while (!glfwWindowShouldClose(win)) {
-    glfwPollEvents();
+    // ----------------------------------------------------
+    // Main render loop
+    // ----------------------------------------------------
+    while (!glfwWindowShouldClose(win))
+    {
+        glfwPollEvents();
 
-    if (g_numFrames > 0) {
-      g_frameIndex = (g_frameIndex + 1) % g_numFrames;
+        if (g_numFrames > 0)
+        {
+            g_frameIndex = (g_frameIndex + 1) % g_numFrames;
+        }
+
+        glClearColor(0.02f, 0.02f, 0.05f, 1.0f); // deep navy space
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+        if (!g_bodies.empty() && g_numFrames > 0)
+        {
+            // Determine camera target position
+            glm::vec3 target(0.0f);
+            switch (g_cameraTarget)
+            {
+            case CameraTarget::Sun:
+                target = getBodyPos("Sun");
+                break;
+            case CameraTarget::Mercury:
+                target = getBodyPos("Mercury");
+                break;
+            case CameraTarget::Venus:
+                target = getBodyPos("Venus");
+                break;
+            case CameraTarget::Earth:
+                target = getBodyPos("Earth");
+                break;
+            case CameraTarget::Moon:
+                target = getBodyPos("Moon");
+                break;
+            case CameraTarget::Mars:
+                target = getBodyPos("Mars");
+                break;
+            case CameraTarget::Jupiter:
+                target = getBodyPos("Jupiter");
+                break;
+            case CameraTarget::Saturn:
+                target = getBodyPos("Saturn");
+                break;
+            case CameraTarget::Uranus:
+                target = getBodyPos("Uranus");
+                break;
+            case CameraTarget::Neptune:
+                target = getBodyPos("Neptune");
+                break;
+            case CameraTarget::Barycenter:
+            default:
+                target = glm::vec3(0.0f);
+                break;
+            }
+
+            // Camera offset in local spherical coords
+            glm::vec3 camOffset(g_radius * cos(g_pitch) * sin(g_yaw), g_radius * sin(g_pitch),
+                                g_radius * cos(g_pitch) * cos(g_yaw));
+
+            glm::vec3 camPos = target + camOffset;
+
+            float aspect = float(g_windowWidth) / float(g_windowHeight);
+
+            // Reverse-Z style infinite perspective: tiny near plane, infinite far.
+            glm::mat4 proj = glm::infinitePerspective(glm::radians(45.0f), aspect,
+                                                      0.000001f // near plane in GL units
+            );
+
+            glm::mat4 view = glm::lookAt(camPos, target, glm::vec3(0, 1, 0));
+
+            glUseProgram(shader);
+
+            // view position for specular
+            glUniform3fv(locViewPos, 1, glm::value_ptr(camPos));
+            // light at Sun position (or origin if missing)
+            glm::vec3 sunPos = getBodyPos("Sun");
+            glUniform3fv(locLight, 1, glm::value_ptr(sunPos));
+
+            // ---------------- N-body draw ----------------
+            size_t frame = g_frameIndex % g_numFrames;
+            for (auto& body : g_bodies)
+            {
+                if (frame >= body.positions.size())
+                    continue;
+                glm::mat4 model = glm::translate(glm::mat4(1.0f), body.positions[frame]);
+                glm::mat4 mvp = proj * view * model;
+                glUniformMatrix4fv(locMVP, 1, GL_FALSE, glm::value_ptr(mvp));
+                glUniformMatrix4fv(locModel, 1, GL_FALSE, glm::value_ptr(model));
+                glUniform3fv(locColor, 1, glm::value_ptr(body.color));
+                body.mesh.draw();
+            }
+        }
+
+        // ------------------------------------------------
+        // HUD legend (Sun / Earth / Moon) – top-left
+        // ------------------------------------------------
+        glDisable(GL_DEPTH_TEST);
+
+        float size = LEGEND_SIZE_PX;
+        float sizeSel = LEGEND_SIZE_PX * 1.4f; // highlight selected
+
+        float y0 = LEGEND_BASE_Y;
+        float y1 = LEGEND_BASE_Y + LEGEND_SPACING;
+        float y2 = LEGEND_BASE_Y + 2.0f * LEGEND_SPACING;
+
+        // Sun icon (top)
+        drawLegendBox(LEGEND_BASE_X, y0, (g_cameraTarget == CameraTarget::Sun ? sizeSel : size),
+                      glm::vec3(1.4f, 1.1f, 0.3f));
+
+        // Earth icon (middle)
+        drawLegendBox(LEGEND_BASE_X, y1, (g_cameraTarget == CameraTarget::Earth ? sizeSel : size),
+                      glm::vec3(0.2f, 0.8f, 1.2f));
+
+        // Moon icon (bottom)
+        drawLegendBox(LEGEND_BASE_X, y2, (g_cameraTarget == CameraTarget::Moon ? sizeSel : size),
+                      glm::vec3(0.85f, 0.85f, 0.92f));
+
+        glEnable(GL_DEPTH_TEST);
+
+        glfwSwapBuffers(win);
     }
 
-    glClearColor(0.02f, 0.02f, 0.05f, 1.0f); // deep navy space
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glfwDestroyWindow(win);
 
-    if (!g_bodies.empty() && g_numFrames > 0) {
-      // Determine camera target position
-      glm::vec3 target(0.0f);
-      switch (g_cameraTarget) {
-      case CameraTarget::Sun:
-        target = getBodyPos("Sun");
-        break;
-      case CameraTarget::Mercury:
-        target = getBodyPos("Mercury");
-        break;
-      case CameraTarget::Venus:
-        target = getBodyPos("Venus");
-        break;
-      case CameraTarget::Earth:
-        target = getBodyPos("Earth");
-        break;
-      case CameraTarget::Moon:
-        target = getBodyPos("Moon");
-        break;
-      case CameraTarget::Mars:
-        target = getBodyPos("Mars");
-        break;
-      case CameraTarget::Jupiter:
-        target = getBodyPos("Jupiter");
-        break;
-      case CameraTarget::Saturn:
-        target = getBodyPos("Saturn");
-        break;
-      case CameraTarget::Uranus:
-        target = getBodyPos("Uranus");
-        break;
-      case CameraTarget::Neptune:
-        target = getBodyPos("Neptune");
-        break;
-      case CameraTarget::Barycenter:
-      default:
-        target = glm::vec3(0.0f);
-        break;
-      }
+    // cleanup legend objects
+    glDeleteBuffers(1, &g_legendVBO);
+    glDeleteVertexArrays(1, &g_legendVAO);
+    glDeleteProgram(g_legendShader);
 
-      // Camera offset in local spherical coords
-      glm::vec3 camOffset(g_radius * cos(g_pitch) * sin(g_yaw),
-                          g_radius * sin(g_pitch),
-                          g_radius * cos(g_pitch) * cos(g_yaw));
-
-      glm::vec3 camPos = target + camOffset;
-
-      float aspect = float(g_windowWidth) / float(g_windowHeight);
-
-      // Reverse-Z style infinite perspective: tiny near plane, infinite far.
-      glm::mat4 proj =
-          glm::infinitePerspective(glm::radians(45.0f), aspect,
-                                   0.000001f // near plane in GL units
-          );
-
-      glm::mat4 view = glm::lookAt(camPos, target, glm::vec3(0, 1, 0));
-
-      glUseProgram(shader);
-
-      // view position for specular
-      glUniform3fv(locViewPos, 1, glm::value_ptr(camPos));
-      // light at Sun position (or origin if missing)
-      glm::vec3 sunPos = getBodyPos("Sun");
-      glUniform3fv(locLight, 1, glm::value_ptr(sunPos));
-
-      // ---------------- N-body draw ----------------
-      size_t frame = g_frameIndex % g_numFrames;
-      for (auto &body : g_bodies) {
-        if (frame >= body.positions.size())
-          continue;
-        glm::mat4 model =
-            glm::translate(glm::mat4(1.0f), body.positions[frame]);
-        glm::mat4 mvp = proj * view * model;
-        glUniformMatrix4fv(locMVP, 1, GL_FALSE, glm::value_ptr(mvp));
-        glUniformMatrix4fv(locModel, 1, GL_FALSE, glm::value_ptr(model));
-        glUniform3fv(locColor, 1, glm::value_ptr(body.color));
-        body.mesh.draw();
-      }
-    }
-
-    // ------------------------------------------------
-    // HUD legend (Sun / Earth / Moon) – top-left
-    // ------------------------------------------------
-    glDisable(GL_DEPTH_TEST);
-
-    float size = LEGEND_SIZE_PX;
-    float sizeSel = LEGEND_SIZE_PX * 1.4f; // highlight selected
-
-    float y0 = LEGEND_BASE_Y;
-    float y1 = LEGEND_BASE_Y + LEGEND_SPACING;
-    float y2 = LEGEND_BASE_Y + 2.0f * LEGEND_SPACING;
-
-    // Sun icon (top)
-    drawLegendBox(LEGEND_BASE_X, y0,
-                  (g_cameraTarget == CameraTarget::Sun ? sizeSel : size),
-                  glm::vec3(1.4f, 1.1f, 0.3f));
-
-    // Earth icon (middle)
-    drawLegendBox(LEGEND_BASE_X, y1,
-                  (g_cameraTarget == CameraTarget::Earth ? sizeSel : size),
-                  glm::vec3(0.2f, 0.8f, 1.2f));
-
-    // Moon icon (bottom)
-    drawLegendBox(LEGEND_BASE_X, y2,
-                  (g_cameraTarget == CameraTarget::Moon ? sizeSel : size),
-                  glm::vec3(0.85f, 0.85f, 0.92f));
-
-    glEnable(GL_DEPTH_TEST);
-
-    glfwSwapBuffers(win);
-  }
-
-  glfwDestroyWindow(win);
-
-  // cleanup legend objects
-  glDeleteBuffers(1, &g_legendVBO);
-  glDeleteVertexArrays(1, &g_legendVAO);
-  glDeleteProgram(g_legendShader);
-
-  glfwTerminate();
-  return 0;
+    glfwTerminate();
+    return 0;
 }


### PR DESCRIPTION
# Summary  
This PR adds a comprehensive Makefile for build orchestration and updates the CI workflow with linting, building, and testing jobs.  
## Changes
### Build System (feat)
- Added Makefile with targets for building, running simulations, and generating plots
- Supports BUILD_VIEWER=0 for headless/CI builds without OpenGL
- Added CMAKE_FLAGS for custom CMake configuration
### CI Pipeline (docs)
- Added lint job: Checks code formatting using clang-format on changed files only
- Added build job: Compiles release binary
- Added test job: Validates system files and runs test simulations
- Jobs run in sequence (lint → build + test in parallel)
### Bug Fix (fix)
- Fixed OpenGL header conflict in orbit_viewer.cpp by reordering glad/glad.h before GLFW/glfw3.h
### Documentation (docs)
- Updated README with Makefile targets table
- Added CI section documenting the workflow
- Updated project structure to include new files
### Example Usage
```bash
make build              # Build all
make run-earth-moon    # Run Earth-Moon simulation  
make test              # Quick validation
make plot-energy       # Generate plots
make BUILD_VIEWER=0 build  # Headless build
```
Breaking Changes   
None.