### PR TITLE
fix(ci): correct release.yml typos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: release
+
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+        run: gh release create ${{ github.ref_name }} --generate-notes


### PR DESCRIPTION
## Summary
- Fix `run-on:` → `runs-on:` (invalid key made the whole workflow file invalid)
- Fix `content: write` → `contents: write` (wrong GITHUB_TOKEN permission scope, would 403 on `gh release create`)
- Fix tag trigger `"v"` → `"v*"` (didn't match any real tag — v1.0.0, v2.0.0, v2.0.1, etc.)

Closes #40

## Test plan
- [ ] Push a `vX.Y.Z` tag (or merge and tag the next release) and confirm the `release` workflow run appears and succeeds
- [ ] Confirm a GitHub Release is created with auto-generated notes